### PR TITLE
feat: assert() macro for CMakeLists

### DIFF
--- a/CMakeEssential.cmake
+++ b/CMakeEssential.cmake
@@ -6,6 +6,7 @@ set_package_properties(
     TYPE RECOMMENDED)
 
 # Provided snippets:
+include("${CMAKE_CURRENT_LIST_DIR}/include/Assert.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/include/Ccache.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/include/Git.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/include/MessageContext.cmake")

--- a/CMakeEssentialConfig.cmake
+++ b/CMakeEssentialConfig.cmake
@@ -1,4 +1,4 @@
-set(CMakeEssential_VERSION 1.0.3)
+set(CMakeEssential_VERSION 1.0.3.2)
 
 
 ####### Expanded from @PACKAGE_INIT@ by configure_package_config_file() #######

--- a/CMakeEssentialConfig.cmake
+++ b/CMakeEssentialConfig.cmake
@@ -1,4 +1,4 @@
-set(CMakeEssential_VERSION 1.0.3.2)
+set(CMakeEssential_VERSION 1.1.0)
 
 
 ####### Expanded from @PACKAGE_INIT@ by configure_package_config_file() #######

--- a/CMakeEssentialConfigVersion.cmake
+++ b/CMakeEssentialConfigVersion.cmake
@@ -9,19 +9,19 @@
 # The variable CVF_VERSION must be set before calling configure_file().
 
 
-set(PACKAGE_VERSION "1.0.3")
+set(PACKAGE_VERSION "1.0.3.2")
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()
 
-  if("1.0.3" MATCHES "^([0-9]+)\\.")
+  if("1.0.3.2" MATCHES "^([0-9]+)\\.")
     set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
     if(NOT CVF_VERSION_MAJOR VERSION_EQUAL 0)
       string(REGEX REPLACE "^0+" "" CVF_VERSION_MAJOR "${CVF_VERSION_MAJOR}")
     endif()
   else()
-    set(CVF_VERSION_MAJOR "1.0.3")
+    set(CVF_VERSION_MAJOR "1.0.3.2")
   endif()
 
   if(PACKAGE_FIND_VERSION_RANGE)

--- a/CMakeEssentialConfigVersion.cmake
+++ b/CMakeEssentialConfigVersion.cmake
@@ -9,19 +9,19 @@
 # The variable CVF_VERSION must be set before calling configure_file().
 
 
-set(PACKAGE_VERSION "1.0.3.2")
+set(PACKAGE_VERSION "1.1.0")
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()
 
-  if("1.0.3.2" MATCHES "^([0-9]+)\\.")
+  if("1.1.0" MATCHES "^([0-9]+)\\.")
     set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
     if(NOT CVF_VERSION_MAJOR VERSION_EQUAL 0)
       string(REGEX REPLACE "^0+" "" CVF_VERSION_MAJOR "${CVF_VERSION_MAJOR}")
     endif()
   else()
-    set(CVF_VERSION_MAJOR "1.0.3.2")
+    set(CVF_VERSION_MAJOR "1.1.0")
   endif()
 
   if(PACKAGE_FIND_VERSION_RANGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include("include/Policies.cmake")
 include("include/Project.cmake")
 
 # This project can be used via 'git subtree' or copy&paste, where git cannot provide the version number.
-set(PROJECT_VERSION "1.0.3.2")
+set(PROJECT_VERSION "1.1.0")
 
 project(
     CMakeEssential
@@ -15,6 +15,7 @@ project(
 project_message_context()
 
 set(provided_snippets
+    "Assert.cmake"
     "Ccache.cmake"
     "Git.cmake"
     "MessageContext.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include("include/Policies.cmake")
 include("include/Project.cmake")
 
 # This project can be used via 'git subtree' or copy&paste, where git cannot provide the version number.
-set(PROJECT_VERSION "1.0.3")
+set(PROJECT_VERSION "1.0.3.2")
 
 project(
     CMakeEssential

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :author: Max FERGER
 // Metadata:
 :description: Essential CMake snippets for software development with modern CMake
-:revnumber: 1.0.3.2
+:revnumber: 1.1.0
 // References:
 :url-repo: https://github.com/UnePierre/cmake-essential
 :url-issues: {url-repo}/-/issues

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :author: Max FERGER
 // Metadata:
 :description: Essential CMake snippets for software development with modern CMake
-:revnumber: 1.0.3
+:revnumber: 1.0.3.2
 // References:
 :url-repo: https://github.com/UnePierre/cmake-essential
 :url-issues: {url-repo}/-/issues
@@ -134,7 +134,7 @@ link:tools/[]::
 link:docs/[]::
     Directory for project documentation.
     -- Contains templates to generate the documentation:
-    * link:docs/README.in.adoc[] -> link:REAMDE.adoc[]
+    * link:docs/README.in.adoc[] -> link:README.adoc[]
 //    * link:docs/LICENSE.in.adoc[] -> link:LICENSE.adoc[]
 
 ////

--- a/docs/README.in.adoc
+++ b/docs/README.in.adoc
@@ -134,7 +134,7 @@ link:tools/[]::
 link:docs/[]::
     Directory for project documentation.
     -- Contains templates to generate the documentation:
-    * link:docs/README.in.adoc[] -> link:REAMDE.adoc[]
+    * link:docs/README.in.adoc[] -> link:README.adoc[]
 //    * link:docs/LICENSE.in.adoc[] -> link:LICENSE.adoc[]
 
 ////

--- a/include/Assert.cmake
+++ b/include/Assert.cmake
@@ -1,0 +1,10 @@
+# assert(<test> [...])
+#
+# Output a SEND_ERROR message, iff the test fails, including the test and all other arguments.
+#
+macro(assert test)
+if(NOT ${test})
+    string(JOIN " " arguments ${ARGV})
+    message(SEND_ERROR "Assertion failed: ${arguments}")
+endif()
+endmacro()

--- a/tools/CMakeLists.in.cmake
+++ b/tools/CMakeLists.in.cmake
@@ -15,6 +15,7 @@ project(
 project_message_context()
 
 set(provided_snippets
+    "Assert.cmake"
     "Ccache.cmake"
     "Git.cmake"
     "MessageContext.cmake"


### PR DESCRIPTION
Several languages have `assert()` macros, that state and test preconditions in a single line.
This can be practical in CMake as well.